### PR TITLE
Fix invalid optimization flag in Makefile.mingw

### DIFF
--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -8,7 +8,7 @@
 #
 #		Makefile for Windows systems using the MinGW32 environment.
 #
-# Version:	@(#)Makefile.mingw	1.0.7	2018/03/05
+# Version:	@(#)Makefile.mingw	1.0.8	2018/03/07
 #
 # Author:	Fred N. van Kempen, <decwiz@yahoo.com>
 #

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -275,7 +275,7 @@ else
  ifeq ($(OPTIM), y)
   AOPTIM	:= -mtune=native
   ifndef COPTIM
-   COPTIM	:= -O6
+   COPTIM	:= -O3
   endif
  else
   ifndef COPTIM


### PR DESCRIPTION
According to GCC documentation -O6 is not a real optimization level, and AFAIK is just treated as -O3 by the compiler, therefore it should be changed to just be -O3.