### PR TITLE
add return in case failing to create the file

### DIFF
--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -578,14 +578,17 @@ void dumpregs(int force)
 	(void)plat_chdir(usr_path);
         nopageerrors=1;
         f=fopen("ram.dmp","wb");
+        if (!f) return;	
         fwrite(ram,mem_size*1024,1,f);
         fclose(f);
         pclog("Dumping rram.dmp\n");
         f=fopen("rram.dmp","wb");
+        if (!f) return;	
         for (c=0;c<0x1000000;c++) putc(readmemb(c),f);
         fclose(f);
         pclog("Dumping rram4.dmp\n");
         f=fopen("rram4.dmp","wb");
+        if (!f) return;	
         for (c=0;c<0x0050000;c++) 
         {
                 cpu_state.abrt = 0;


### PR DESCRIPTION
Hi all,

There are some file created by not checked found by Qihoo360 CodeSafe Team.

Even the file is create in 'usr_path', it is better and more safely to check whether the file is created successfully.
The check against null pointer could protect the program from deference a null pointer.