### PR TITLE
add checking against NULL returned by malloc

### DIFF
--- a/src/devices/video/vid_paradise.c
+++ b/src/devices/video/vid_paradise.c
@@ -305,6 +305,7 @@ static uint16_t paradise_readw(uint32_t addr, void *p)
 static void *paradise_pvga1a_init(const device_t *info, uint32_t memsize)
 {
         paradise_t *paradise = malloc(sizeof(paradise_t));
+	if (!paradise) return NULL;
         svga_t *svga = &paradise->svga;
         memset(paradise, 0, sizeof(paradise_t));
         
@@ -338,6 +339,7 @@ static void *paradise_pvga1a_init(const device_t *info, uint32_t memsize)
 static void *paradise_wd90c11_init(const device_t *info)
 {
         paradise_t *paradise = malloc(sizeof(paradise_t));
+	if (!paradise) return NULL;
         svga_t *svga = &paradise->svga;
         memset(paradise, 0, sizeof(paradise_t));
         
@@ -373,6 +375,7 @@ static void *paradise_wd90c11_init(const device_t *info)
 static void *paradise_wd90c30_init(const device_t *info, uint32_t memsize)
 {
         paradise_t *paradise = malloc(sizeof(paradise_t));
+	if (!paradise) return NULL;
         svga_t *svga = &paradise->svga;
         memset(paradise, 0, sizeof(paradise_t));
         

--- a/src/devices/video/vid_paradise.c
+++ b/src/devices/video/vid_paradise.c
@@ -305,7 +305,7 @@ static uint16_t paradise_readw(uint32_t addr, void *p)
 static void *paradise_pvga1a_init(const device_t *info, uint32_t memsize)
 {
         paradise_t *paradise = malloc(sizeof(paradise_t));
-	if (!paradise) return NULL;
+        if (!paradise) return NULL;
         svga_t *svga = &paradise->svga;
         memset(paradise, 0, sizeof(paradise_t));
         
@@ -339,7 +339,7 @@ static void *paradise_pvga1a_init(const device_t *info, uint32_t memsize)
 static void *paradise_wd90c11_init(const device_t *info)
 {
         paradise_t *paradise = malloc(sizeof(paradise_t));
-	if (!paradise) return NULL;
+        if (!paradise) return NULL;
         svga_t *svga = &paradise->svga;
         memset(paradise, 0, sizeof(paradise_t));
         
@@ -375,7 +375,7 @@ static void *paradise_wd90c11_init(const device_t *info)
 static void *paradise_wd90c30_init(const device_t *info, uint32_t memsize)
 {
         paradise_t *paradise = malloc(sizeof(paradise_t));
-	if (!paradise) return NULL;
+        if (!paradise) return NULL;
         svga_t *svga = &paradise->svga;
         memset(paradise, 0, sizeof(paradise_t));
         


### PR DESCRIPTION
Hi all,
There are some bad checking against NULL found by Qihoo360 CodeSafe Team.

Details as bellow:

In some cases such as memory exhausted, function malloc() may return a null pointer.
In function paradise_pvga1a_init(), paradise_wd90c11_init() and paradise_wd90c30_init(), we just use the return pointer of malloc without checking against NULL, but after calling such function as line 412, line 421, line 437, line 452, line 465 and line 486, the return value is checked against NULL. If the return value of malloc() a null pointer, the check will be too late (and since the value is directly return by 'paradise_*()' function, the check we use now is no effect).