### PR TITLE
MSVC: Make the new malloc() wrapper optional

### DIFF
--- a/src/emu.h
+++ b/src/emu.h
@@ -8,7 +8,7 @@
  *
  *		Main include file for the application.
  *
- * Version:	@(#)emu.h	1.0.32	2018/09/23
+ * Version:	@(#)emu.h	1.0.33	2018/10/03
  *
  * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
  *
@@ -198,8 +198,13 @@ extern void		set_screen_size_natural(void);
 
 extern const wchar_t	*get_string(int id);
 extern uint32_t		get_val(const char *str);
+
+#ifndef USE_STANDARD_MALLOC
+
 extern void		*mem_alloc(size_t sz);
 #define malloc		mem_alloc
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -8,7 +8,7 @@
  *
  *		Misc functions that do not fit anywhere else.
  *
- * Version:	@(#)misc.c	1.0.2	2018/09/22
+ * Version:	@(#)misc.c	1.0.3	2018/10/03
  *
  * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
  *
@@ -88,6 +88,7 @@ get_val(const char *str)
     return(l);
 }
 
+#ifndef USE_STANDARD_MALLOC
 
 /* Safe version of malloc(3) that catches NULL returns. */
 void *
@@ -110,3 +111,5 @@ mem_alloc(size_t sz)
 
     return(ptr);
 }
+
+#endif

--- a/src/win/msvc/vc15/VARCem.vcxproj
+++ b/src/win/msvc/vc15/VARCem.vcxproj
@@ -701,7 +701,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;USE_STANDARD_MALLOC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -740,7 +740,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;USE_STANDARD_MALLOC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
It causes issues with DLL linkage on MSVC (DLLImport/DLLExport) so let's just disable it for now...

Default is still enabled, define `USE_STANDARD_MALLOC` to disable it.

Also update MSVC project files to disable the wrapper for debug and release builds.