### PR TITLE
MSVC: Here are the current fixes for the new version

### DIFF
--- a/src/devices/system/i82335.c
+++ b/src/devices/system/i82335.c
@@ -40,6 +40,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <wchar.h>
+#include "../../emu.h"
 #include "../../io.h"
 #include "../../mem.h"
 #include "../../plat.h"

--- a/src/win/msvc/vc15/VARCem.vcxproj
+++ b/src/win/msvc/vc15/VARCem.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\devices\cdrom\cdrom_speed.c" />
     <ClCompile Include="..\..\..\devices\misc\bugger.c" />
     <ClCompile Include="..\..\..\devices\cdrom\cdrom.c" />
     <ClCompile Include="..\..\..\devices\cdrom\cdrom_dosbox.cpp" />
@@ -55,6 +56,11 @@
     <ClCompile Include="..\..\..\devices\disk\hdd_image.c" />
     <ClCompile Include="..\..\..\devices\disk\hdd_table.c" />
     <ClCompile Include="..\..\..\devices\disk\zip.c" />
+    <ClCompile Include="..\..\..\devices\misc\isamem.c" />
+    <ClCompile Include="..\..\..\devices\misc\isartc.c" />
+    <ClCompile Include="..\..\..\devices\network\net_3c503.c" />
+    <ClCompile Include="..\..\..\devices\network\net_dp8390.c" />
+    <ClCompile Include="..\..\..\devices\network\net_wd80x3.c" />
     <ClCompile Include="..\..\..\devices\network\slirp\bootp.c" />
     <ClCompile Include="..\..\..\devices\network\slirp\cksum.c" />
     <ClCompile Include="..\..\..\devices\network\slirp\debug.c" />
@@ -73,9 +79,11 @@
     <ClCompile Include="..\..\..\devices\network\slirp\tcp_subr.c" />
     <ClCompile Include="..\..\..\devices\network\slirp\tcp_timer.c" />
     <ClCompile Include="..\..\..\devices\network\slirp\udp.c" />
+    <ClCompile Include="..\..\..\devices\printer\prt_cpmap.c" />
+    <ClCompile Include="..\..\..\devices\printer\prt_escp.c" />
+    <ClCompile Include="..\..\..\devices\printer\prt_text.c" />
     <ClCompile Include="..\..\..\devices\scsi\scsi.c" />
     <ClCompile Include="..\..\..\devices\scsi\scsi_aha154x.c" />
-    <ClCompile Include="..\..\..\devices\scsi\scsi_bus.c" />
     <ClCompile Include="..\..\..\devices\scsi\scsi_buslogic.c" />
     <ClCompile Include="..\..\..\devices\scsi\scsi_device.c" />
     <ClCompile Include="..\..\..\devices\scsi\scsi_disk.c" />
@@ -160,7 +168,6 @@
     <ClCompile Include="..\..\..\devices\system\intel.c" />
     <ClCompile Include="..\..\..\devices\system\intel_flash.c" />
     <ClCompile Include="..\..\..\devices\system\intel_piix.c" />
-    <ClCompile Include="..\..\..\devices\system\intel_piix4.c" />
     <ClCompile Include="..\..\..\devices\system\intel_sio.c" />
     <ClCompile Include="..\..\..\devices\system\mca.c" />
     <ClCompile Include="..\..\..\devices\system\mcr.c" />
@@ -197,17 +204,14 @@
     <ClCompile Include="..\..\..\devices\input\mouse_ps2.c" />
     <ClCompile Include="..\..\..\devices\input\mouse_serial.c" />
     <ClCompile Include="..\..\..\devices\video\video_dev.c" />
+    <ClCompile Include="..\..\..\devices\video\vid_bt48x_ramdac.c" />
+    <ClCompile Include="..\..\..\devices\video\vid_cga_compaq.c" />
     <ClCompile Include="..\..\..\io.c" />
     <ClCompile Include="..\..\..\machines\machine.c" />
     <ClCompile Include="..\..\..\machines\machine_table.c" />
     <ClCompile Include="..\..\..\machines\m_amstrad.c" />
     <ClCompile Include="..\..\..\machines\m_at.c" />
-    <ClCompile Include="..\..\..\machines\m_at_430fx.c" />
-    <ClCompile Include="..\..\..\machines\m_at_430hx.c" />
-    <ClCompile Include="..\..\..\machines\m_at_430lx_nx.c" />
-    <ClCompile Include="..\..\..\machines\m_at_430vx.c" />
-    <ClCompile Include="..\..\..\machines\m_at_440fx.c" />
-    <ClCompile Include="..\..\..\machines\m_at_4gpv31.c" />
+    <ClCompile Include="..\..\..\machines\m_at_4x0.c" />
     <ClCompile Include="..\..\..\machines\m_at_ali1429.c" />
     <ClCompile Include="..\..\..\machines\m_at_commodore.c" />
     <ClCompile Include="..\..\..\machines\m_at_compaq.c" />
@@ -217,7 +221,6 @@
     <ClCompile Include="..\..\..\machines\m_at_scat.c" />
     <ClCompile Include="..\..\..\machines\m_at_sis_85c471.c" />
     <ClCompile Include="..\..\..\machines\m_at_sis_85c496.c" />
-    <ClCompile Include="..\..\..\machines\m_at_sis_85c50x.c" />
     <ClCompile Include="..\..\..\machines\m_at_t3100e.c" />
     <ClCompile Include="..\..\..\machines\m_at_t3100e_vid.c" />
     <ClCompile Include="..\..\..\machines\m_at_wd76c10.c" />
@@ -248,13 +251,17 @@
     <ClCompile Include="..\..\..\devices\ports\parallel.c" />
     <ClCompile Include="..\..\..\devices\ports\parallel_dev.c" />
     <ClCompile Include="..\..\..\devices\ports\serial.c" />
+    <ClCompile Include="..\..\..\png.c" />
     <ClCompile Include="..\..\..\random.c" />
     <ClCompile Include="..\..\..\rom.c" />
     <ClCompile Include="..\..\..\rom_load.c" />
     <ClCompile Include="..\..\..\devices\sound\munt\c_interface\c_interface.cpp" />
     <ClCompile Include="..\..\..\devices\sound\munt\sha1\sha1.cpp" />
     <ClCompile Include="..\..\..\timer.c" />
+    <ClCompile Include="..\..\..\ui\ui_cdrom.c" />
+    <ClCompile Include="..\..\..\ui\ui_lang.c" />
     <ClCompile Include="..\..\..\ui\ui_main.c" />
+    <ClCompile Include="..\..\..\ui\ui_misc.c" />
     <ClCompile Include="..\..\..\ui\ui_new_image.c" />
     <ClCompile Include="..\..\..\ui\ui_stbar.c" />
     <ClCompile Include="..\..\..\devices\video\video.c" />
@@ -263,12 +270,10 @@
     <ClCompile Include="..\..\..\devices\video\vid_ati68860_ramdac.c" />
     <ClCompile Include="..\..\..\devices\video\vid_ati_eeprom.c" />
     <ClCompile Include="..\..\..\devices\video\vid_ati_mach64.c" />
-    <ClCompile Include="..\..\..\devices\video\vid_bt485_ramdac.c" />
     <ClCompile Include="..\..\..\devices\video\vid_cga.c" />
     <ClCompile Include="..\..\..\devices\video\vid_cga_comp.c" />
     <ClCompile Include="..\..\..\devices\video\vid_cl54xx.c" />
     <ClCompile Include="..\..\..\devices\video\vid_colorplus.c" />
-    <ClCompile Include="..\..\..\devices\video\vid_compaq_cga.c" />
     <ClCompile Include="..\..\..\devices\video\vid_ega.c" />
     <ClCompile Include="..\..\..\devices\video\vid_ega_render.c" />
     <ClCompile Include="..\..\..\devices\video\vid_et4000.c" />
@@ -300,7 +305,6 @@
     <ClCompile Include="..\..\..\win\win.c" />
     <ClCompile Include="..\..\..\win\win_about.c" />
     <ClCompile Include="..\..\..\win\win_cdrom.c" />
-    <ClCompile Include="..\..\..\win\win_cdrom_ioctl.c" />
     <ClCompile Include="..\..\..\win\win_crashdump.c" />
     <ClCompile Include="..\..\..\win\win_d3d.cpp" />
     <ClCompile Include="..\..\..\win\win_ddraw.cpp" />
@@ -314,7 +318,6 @@
     <ClCompile Include="..\..\..\win\win_opendir.c" />
     <ClCompile Include="..\..\..\win\win_settings.c" />
     <ClCompile Include="..\..\..\win\win_snd_gain.c" />
-    <ClCompile Include="..\..\..\win\win_status.c" />
     <ClCompile Include="..\..\..\win\win_thread.c" />
     <ClCompile Include="..\..\..\win\win_ui.c" />
     <ClCompile Include="..\..\win_lang.c" />
@@ -400,6 +403,11 @@
     <ClInclude Include="..\..\..\devices\disk\hdc_ide.h" />
     <ClInclude Include="..\..\..\devices\disk\hdd.h" />
     <ClInclude Include="..\..\..\devices\disk\zip.h" />
+    <ClInclude Include="..\..\..\devices\misc\isamem.h" />
+    <ClInclude Include="..\..\..\devices\misc\isartc.h" />
+    <ClInclude Include="..\..\..\devices\network\net_3com.h" />
+    <ClInclude Include="..\..\..\devices\network\net_dp8390.h" />
+    <ClInclude Include="..\..\..\devices\network\net_wd80x3.h" />
     <ClInclude Include="..\..\..\devices\network\slirp\bootp.h" />
     <ClInclude Include="..\..\..\devices\network\slirp\ctl.h" />
     <ClInclude Include="..\..\..\devices\network\slirp\debug.h" />
@@ -421,6 +429,7 @@
     <ClInclude Include="..\..\..\devices\network\slirp\tcp_timer.h" />
     <ClInclude Include="..\..\..\devices\network\slirp\tcp_var.h" />
     <ClInclude Include="..\..\..\devices\network\slirp\udp.h" />
+    <ClInclude Include="..\..\..\devices\printer\printer.h" />
     <ClInclude Include="..\..\..\devices\scsi\queue.h" />
     <ClInclude Include="..\..\..\devices\scsi\scsi.h" />
     <ClInclude Include="..\..\..\devices\scsi\scsi_aha154x.h" />
@@ -502,6 +511,7 @@
     <ClInclude Include="..\..\..\devices\system\pic.h" />
     <ClInclude Include="..\..\..\devices\system\pit.h" />
     <ClInclude Include="..\..\..\devices\system\ppi.h" />
+    <ClInclude Include="..\..\..\devices\video\vid_bt48x_ramdac.h" />
     <ClInclude Include="..\..\..\emu.h" />
     <ClInclude Include="..\..\..\devices\floppy\fdc.h" />
     <ClInclude Include="..\..\..\devices\floppy\fdd.h" />
@@ -536,6 +546,7 @@
     <ClInclude Include="..\..\..\devices\ports\parallel.h" />
     <ClInclude Include="..\..\..\devices\ports\parallel_dev.h" />
     <ClInclude Include="..\..\..\devices\ports\serial.h" />
+    <ClInclude Include="..\..\..\png.h" />
     <ClInclude Include="..\..\..\random.h" />
     <ClInclude Include="..\..\..\rom.h" />
     <ClInclude Include="..\..\..\devices\sound\munt\c_interface\cpp_interface.h" />
@@ -549,7 +560,6 @@
     <ClInclude Include="..\..\..\devices\video\video.h" />
     <ClInclude Include="..\..\..\devices\video\vid_ati68860_ramdac.h" />
     <ClInclude Include="..\..\..\devices\video\vid_ati_eeprom.h" />
-    <ClInclude Include="..\..\..\devices\video\vid_bt485_ramdac.h" />
     <ClInclude Include="..\..\..\devices\video\vid_cga.h" />
     <ClInclude Include="..\..\..\devices\video\vid_cga_comp.h" />
     <ClInclude Include="..\..\..\devices\video\vid_ega.h" />
@@ -565,7 +575,6 @@
     <ClInclude Include="..\..\..\devices\video\vid_voodoo_codegen_x86-64.h" />
     <ClInclude Include="..\..\..\devices\video\vid_voodoo_codegen_x86.h" />
     <ClInclude Include="..\..\..\devices\video\vid_voodoo_dither.h" />
-    <ClInclude Include="..\..\..\win\plat_dir.h" />
     <ClInclude Include="..\..\..\win\resource.h" />
     <ClInclude Include="..\..\..\win\win.h" />
     <ClInclude Include="..\..\win_opendir.h" />

--- a/src/win/msvc/vc15/VARCem.vcxproj.filters
+++ b/src/win/msvc/vc15/VARCem.vcxproj.filters
@@ -70,9 +70,6 @@
     <ClCompile Include="..\..\..\win\win_cdrom.c">
       <Filter>win</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\win\win_cdrom_ioctl.c">
-      <Filter>win</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\win\win_crashdump.c">
       <Filter>win</Filter>
     </ClCompile>
@@ -110,9 +107,6 @@
       <Filter>win</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\win\win_snd_gain.c">
-      <Filter>win</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\win\win_status.c">
       <Filter>win</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\win\win_thread.c">
@@ -330,9 +324,6 @@
       <Filter>devices\scsi</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\devices\scsi\scsi_aha154x.c">
-      <Filter>devices\scsi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\devices\scsi\scsi_bus.c">
       <Filter>devices\scsi</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\devices\scsi\scsi_buslogic.c">
@@ -593,9 +584,6 @@
     <ClCompile Include="..\..\..\devices\system\intel_piix.c">
       <Filter>devices\system</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\devices\system\intel_piix4.c">
-      <Filter>devices\system</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\devices\system\intel_sio.c">
       <Filter>devices\system</Filter>
     </ClCompile>
@@ -644,9 +632,6 @@
     <ClCompile Include="..\..\..\devices\video\vid_ati68860_ramdac.c">
       <Filter>devices\video</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\devices\video\vid_bt485_ramdac.c">
-      <Filter>devices\video</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\devices\video\vid_cga.c">
       <Filter>devices\video</Filter>
     </ClCompile>
@@ -657,9 +642,6 @@
       <Filter>devices\video</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\devices\video\vid_colorplus.c">
-      <Filter>devices\video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\devices\video\vid_compaq_cga.c">
       <Filter>devices\video</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\devices\video\vid_ega.c">
@@ -752,24 +734,6 @@
     <ClCompile Include="..\..\..\machines\m_at.c">
       <Filter>machines</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\machines\m_at_4gpv31.c">
-      <Filter>machines</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\machines\m_at_430fx.c">
-      <Filter>machines</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\machines\m_at_430hx.c">
-      <Filter>machines</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\machines\m_at_430lx_nx.c">
-      <Filter>machines</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\machines\m_at_430vx.c">
-      <Filter>machines</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\machines\m_at_440fx.c">
-      <Filter>machines</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\machines\m_at_ali1429.c">
       <Filter>machines</Filter>
     </ClCompile>
@@ -789,9 +753,6 @@
       <Filter>machines</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\machines\m_at_scat.c">
-      <Filter>machines</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\machines\m_at_sis_85c50x.c">
       <Filter>machines</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\machines\m_at_sis_85c471.c">
@@ -881,6 +842,52 @@
     </ClCompile>
     <ClCompile Include="..\..\win_lang.c">
       <Filter>win</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\cdrom\cdrom_speed.c">
+      <Filter>devices\cdrom</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\misc\isamem.c">
+      <Filter>devices\misc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\misc\isartc.c">
+      <Filter>devices\misc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\network\net_3c503.c">
+      <Filter>devices\network</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\network\net_dp8390.c">
+      <Filter>devices\network</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\network\net_wd80x3.c">
+      <Filter>devices\network</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\printer\prt_cpmap.c">
+      <Filter>devices\printer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\printer\prt_escp.c">
+      <Filter>devices\printer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\printer\prt_text.c">
+      <Filter>devices\printer</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\video\vid_bt48x_ramdac.c">
+      <Filter>devices\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\devices\video\vid_cga_compaq.c">
+      <Filter>devices\video</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\machines\m_at_4x0.c">
+      <Filter>machines</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ui\ui_cdrom.c">
+      <Filter>ui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\ui\ui_lang.c">
+      <Filter>ui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\png.c" />
+    <ClCompile Include="..\..\..\ui\ui_misc.c">
+      <Filter>ui</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1094,9 +1101,6 @@
     </ClInclude>
     <ClInclude Include="..\..\..\cpu\x87_ops_misc.h">
       <Filter>cpu</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\win\plat_dir.h">
-      <Filter>win</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\win\resource.h">
       <Filter>win</Filter>
@@ -1534,9 +1538,6 @@
     <ClInclude Include="..\..\..\devices\video\vid_ati68860_ramdac.h">
       <Filter>devices\video</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\devices\video\vid_bt485_ramdac.h">
-      <Filter>devices\video</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\..\devices\video\vid_cga.h">
       <Filter>devices\video</Filter>
     </ClInclude>
@@ -1636,6 +1637,28 @@
     <ClInclude Include="..\..\win_settings_video.h">
       <Filter>win</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\devices\misc\isamem.h">
+      <Filter>devices\misc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\devices\misc\isartc.h">
+      <Filter>devices\misc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\devices\network\net_3com.h">
+      <Filter>devices\network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\devices\network\net_dp8390.h">
+      <Filter>devices\network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\devices\network\net_wd80x3.h">
+      <Filter>devices\network</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\devices\printer\printer.h">
+      <Filter>devices\printer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\devices\video\vid_bt48x_ramdac.h">
+      <Filter>devices\video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\png.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="cpu">
@@ -1709,6 +1732,9 @@
     </Filter>
     <Filter Include="devices\misc">
       <UniqueIdentifier>{51f1c4aa-4a2a-4639-bcbc-2075ffaf3e27}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="devices\printer">
+      <UniqueIdentifier>{4797388a-1c9d-4a4c-a7f9-aa1925cad334}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/win/win_serial.c
+++ b/src/win/win_serial.c
@@ -54,8 +54,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #define PLAT_SERIAL_C
-#include "../../emu.h"
-#include "../../plat.h"
+#include "../emu.h"
+#include "../plat.h"
 #include "../devices/ports/serial.h"
 
 

--- a/src/win/win_settings_disk.h
+++ b/src/win/win_settings_disk.h
@@ -789,7 +789,7 @@ disk_add_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
     wchar_t temp_path[512];
     char buf[512], *big_buf;
-    HWND h;
+    HWND h = INVALID_HANDLE_VALUE;
     uint64_t i = 0;
     uint64_t temp;
     FILE *f;


### PR DESCRIPTION
Fix some uninitialized variable warning, fix the include paths in an unused file (yes, I know, it's unused but hey...) and add a missing include (how do other compilers not choke on that?). Oh and update the MSVC project files, of course...