### PR TITLE
MSVC: Fix some warnings and add proper #defines required for string format specifiers (take 2)

### DIFF
--- a/src/devices/network/net_3com.h
+++ b/src/devices/network/net_3com.h
@@ -32,7 +32,7 @@
  *   Boston, MA 02111-1307
  *   USA.
  */
-#ifndef NET_3COME_H
+#ifndef NET_3COM_H
 # define NET_3COM_H
 
 

--- a/src/devices/ports/game.c
+++ b/src/devices/ports/game.c
@@ -79,9 +79,9 @@ int		game_do_log = ENABLE_GAME_LOG;
 void
 game_log(int level, const char *fmt, ...)
 {
-    va_list ap;
-
 #ifdef ENABLE_GAME_LOG
+	va_list ap;
+
     if (game_do_log >= level) {
 	va_start(ap, fmt);
 	pclog_ex(fmt, ap);

--- a/src/win/msvc/vc15/global.props
+++ b/src/win/msvc/vc15/global.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;USE_DYNAREC;USE_OPENAL;USE_SDL</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_NONSTDC_NO_DEPRECATE;_WINSOCK_DEPRECATED_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_CRT_STDIO_ISO_WIDE_SPECIFIERS;USE_DYNAREC;USE_OPENAL;USE_SDL;USE_FLUIDSYNTH</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup />


### PR DESCRIPTION
now without sio_detect.c, and with another fix (incorrect include guard usage in `net_3com.h`)