### PR TITLE
Add a PCAP naming fallback

### DIFF
--- a/src/devices/network/net_pcap.c
+++ b/src/devices/network/net_pcap.c
@@ -211,10 +211,15 @@ do_init(netdev_t *list)
     /* Process the list and build our table. */
     for (dev = devlist; dev != NULL; dev=dev->next) {
 	strcpy(list->device, dev->name);
-	if (dev->description)
-		strcpy(list->description, dev->description);
-	  else
-		memset(list->description, '\0', sizeof(list->description));
+    if (dev->description) {
+        if (strlen(dev->description) <= 127)
+            strcpy(list->description, dev->description);
+        else
+            strncpy(list->description, dev->description, 127);
+    } else {
+        /* if description is NULL, set the name. This allows pcap to display *something* useful under WINE */
+        strncpy(list->description, dev->name, sizeof(list->description)-1);
+    }
 	list++; i++;
     }
 


### PR DESCRIPTION
Under some circumstances, pcap devices can have a null name (this is true under winpcap-WINE), which leaves the pcap list blank. This pull adds a failsafe that if the description is blank, it juse uses the raw name, which at least populates the list of pcap devices without leaving blanks.